### PR TITLE
fix: typography switch, text-left alignment, AligIcon's active state, types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,14 +9,14 @@ import { StringTemplate } from './components/StringTemplate'
 import { Title } from './components/Title'
 import { Button } from './components/common/Button'
 import { FontSizeSlider } from './components/FontSizeSlider'
-import { TYPOGRAPHY } from './constants'
+import { TYPOGRAPHY, type Typography } from './constants'
 
-function App () {
+function App() {
   const [fontSize, setFontSize] = useState(16)
   const [currentString, setCurrentString] = useState<Array<string>>([])
-  const [fontFamily, setFontFamily] = useState<string>(TYPOGRAPHY.INTER)
+  const [fontFamily, setFontFamily] = useState<Typography>(TYPOGRAPHY.INTER)
 
-  const handleKeyPress = (event: { key: string }) => {
+  const handleKeyPress = (event: KeyboardEvent) => {
     const keyPressed: string = event.key.toLowerCase()
     console.log(currentString.join(''))
     if (currentString.length >= 8) {
@@ -25,7 +25,7 @@ function App () {
     setCurrentString([...currentString, keyPressed])
   }
 
-  const handleChangeTypography = (typography: string) => {
+  const handleChangeTypography = (typography: Typography) => {
     setFontFamily(typography)
   }
 
@@ -49,15 +49,14 @@ function App () {
     showToast(code)
   }
 
-  const { fontSize: calculatedFontSize, lineHeight } =
-    calculateLineHeight(fontSize)
+  const { lineHeight } = calculateLineHeight(fontSize)
 
   return (
     <>
-      <main className='flex-1 mt-50 w-full h-full flex flex-col justify-center items-center overflow-hidden'>
+      <main className="flex-1 mt-50 w-full h-full flex flex-col justify-center items-center overflow-hidden">
         <Title />
-        <section className='grid grid-cols-2 flex-1 mt-10 gap-x-24 max-w-5xl mx-auto overflow-hidden'>
-          <article className='w-full space-y-8'>
+        <section className="grid grid-cols-2 flex-1 mt-10 gap-x-24 max-w-5xl mx-auto overflow-hidden">
+          <article className="w-full space-y-8">
             <FontSizeSlider
               fontSize={fontSize}
               fontFamily={fontFamily}
@@ -65,14 +64,14 @@ function App () {
               onFontChange={handleChangeTypography}
             />
 
-            <div className='flex justify-between items-center font-semibold my-4 text-[24px]'>
-              <p className='text-cTextPrimary'>Line Height</p>
-              <p className='p-2 text-cTextPrimary border-2 border-cPrimary rounded-[4px] flex items-center justify-center w-[64px] h-[40px]'>
+            <div className="flex justify-between items-center font-semibold my-4 text-[24px]">
+              <p className="text-cTextPrimary">Line Height</p>
+              <p className="p-2 text-cTextPrimary border-2 border-cPrimary rounded-[4px] flex items-center justify-center w-[64px] h-[40px]">
                 {lineHeight.toFixed(2)}
               </p>
             </div>
 
-            <div className='flex w-full justify-center'>
+            <div className="flex w-full justify-center">
               <Button onClick={generateCode}>Copy CSS</Button>
             </div>
           </article>

--- a/src/components/FontSizeSlider.tsx
+++ b/src/components/FontSizeSlider.tsx
@@ -1,11 +1,11 @@
-import { ChevronDown, ChevronUp } from 'lucide-react'
-import { TYPOGRAPHY } from '../constants'
+import { ChevronDown } from 'lucide-react'
+import { TYPOGRAPHY, type Typography } from '../constants'
 
 type Props = {
   fontSize: number
-  fontFamily: string
+  fontFamily: Typography
   setFontSize: (fontSize: number) => void
-  onFontChange: (typography: string) => void
+  onFontChange: (typography: Typography) => void
 }
 
 export const FontSizeSlider = (props: Props) => {
@@ -20,12 +20,14 @@ export const FontSizeSlider = (props: Props) => {
 
   return (
     <>
-      <div className='grid'>
-        <div className='relative w-full flex items-center'>
+      <div className="grid">
+        <div className="relative w-full flex items-center">
           <select
-            onChange={event => onFontChange(event?.target.value)}
+            onChange={(event) =>
+              onFontChange(event?.target.value as Typography)
+            }
             value={fontFamily}
-            className='grow appearance-none bg-transparent row-start-1 col-start-1 border-2 border-cPrimary text-cTextPrimary p-2 font-semibold'
+            className="grow appearance-none bg-transparent row-start-1 col-start-1 border-2 border-cPrimary text-cTextPrimary p-2 font-semibold"
           >
             <option className={optionStyle} value={TYPOGRAPHY.INTER}>
               Inter
@@ -37,25 +39,25 @@ export const FontSizeSlider = (props: Props) => {
               Montserrat
             </option>
           </select>
-          <ChevronDown className='text-cTextPrimary absolute right-4' />
+          <ChevronDown className="text-cTextPrimary absolute right-4 events-none" />
         </div>
       </div>
-      <div className='flex justify-between items-center font-semibold mb-4 text-[24px]'>
+      <div className="flex justify-between items-center font-semibold mb-4 text-[24px]">
         <label>
-          <p className='text-cTextPrimary'>Font Size</p>
+          <p className="text-cTextPrimary">Font Size</p>
         </label>
-        <p className='p-2 text-cTextPrimary border-2 border-cPrimary rounded-[4px] flex items-center justify-center w-[64px] h-[40px]'>
+        <p className="p-2 text-cTextPrimary border-2 border-cPrimary rounded-[4px] flex items-center justify-center w-[64px] h-[40px]">
           {fontSize}
         </p>
       </div>
-      <div className='grid place-items-center'>
+      <div className="grid place-items-center">
         <input
-          type='range'
-          min='8'
-          max='72'
+          type="range"
+          min="8"
+          max="72"
           value={fontSize}
           onChange={handleFontSizeChange}
-          className='custom-slider bg-transparent appearance-none cursor-pointer w-60'
+          className="custom-slider bg-transparent appearance-none cursor-pointer w-60"
         />
       </div>
     </>

--- a/src/components/StringTemplate.tsx
+++ b/src/components/StringTemplate.tsx
@@ -1,24 +1,29 @@
 import { useState } from 'react'
 import { AlignIcon } from './common/AlignIcon'
 import { AlignLeft, AlignJustify, AlignRight } from 'lucide-react'
-import { MODE, MODE_VIEW_TO_ALIGNMENT } from '../constants'
+import {
+  MODE,
+  MODE_VIEW_TO_ALIGNMENT,
+  type ModeView,
+  type Typography
+} from '../constants'
 
 export const StringTemplate = ({
   fontSize,
   fontFamily
 }: {
   fontSize: number
-  fontFamily: string
+  fontFamily: Typography
 }) => {
-  const [modeView, setModeView] = useState(MODE.LEFT)
+  const [modeView, setModeView] = useState<ModeView>(MODE.LEFT)
 
-  const handleView = (view: string) => {
+  const handleView = (view: ModeView) => {
     setModeView(view)
   }
 
   return (
-    <div className='space-y-4'>
-      <div className='flex gap-x-2 w-fit h-fit'>
+    <div className="space-y-4">
+      <div className="flex gap-x-2 w-fit h-fit">
         <AlignIcon
           active={modeView === MODE.LEFT}
           onClick={() => handleView(MODE.LEFT)}
@@ -39,7 +44,7 @@ export const StringTemplate = ({
         </AlignIcon>
       </div>
       <article
-        className='custom-lines p-6 w-full text-cTextSecondary font-semibold'
+        className="custom-lines p-6 w-full text-cTextSecondary font-semibold"
         style={{ fontSize: fontSize }}
       >
         <p className={`${MODE_VIEW_TO_ALIGNMENT[modeView]} font-${fontFamily}`}>

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,10 +1,10 @@
 export const Title = () => {
   return (
     <>
-      <h1 className='text-[90px] font-bold bg-gradient-to-b from-[#97A8DB] via-[#EBEEF8] to-[#546391] text-transparent bg-clip-text'>
+      <h1 className="text-[90px] font-bold bg-gradient-to-b from-[#97A8DB] via-[#EBEEF8] to-[#546391] text-transparent bg-clip-text">
         Perfect Line Height
       </h1>
-      <h2 className='text-[24px] text-cTextPrimary'>
+      <h2 className="text-[24px] text-cTextPrimary">
         Know the perfect height of your lines based on your font size.
       </h2>
     </>

--- a/src/components/common/AlignIcon.tsx
+++ b/src/components/common/AlignIcon.tsx
@@ -10,9 +10,9 @@ export const AlignIcon = (props: Props) => {
   return (
     <button
       onClick={onClick}
-      className={`bg-cPrimary hover:bg-[#374257] p-1 text-cTextPrimary rounded-[4px] ${
-        active && 'border-2 border-bluegray'
-      }  `}
+      className={`bg-cPrimary hover:bg-[#374257] p-1 text-cTextPrimary rounded-[4px] border-2 border-solid ${
+        active ? 'border-bluegray' : 'border-transparent'
+      }`}
     >
       {children}
     </button>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,7 +9,7 @@ export const Button = (props: Props) => {
   return (
     <button
       onClick={onClick}
-      className='flex items-center h-10 px-8 text-lg text-cTextPrimary font-semibold transition-colors duration-150 bg-cPrimary rounded-[4px] cursor-pointer focus:shadow-outline hover:bg-[#374257]'
+      className="flex items-center h-10 px-8 text-lg text-cTextPrimary font-semibold transition-colors duration-150 bg-cPrimary rounded-[4px] cursor-pointer focus:shadow-outline hover:bg-[#374257]"
     >
       {children}
     </button>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export const MODE = {
   LEFT: 'left',
   CENTER: 'center',
   RIGHT: 'right'
-}
+} as const
+export type ModeView = (typeof MODE)[keyof typeof MODE]
 
 export const MODE_VIEW_TO_ALIGNMENT = {
   [MODE.LEFT]: 'text-left',
@@ -14,4 +15,11 @@ export const TYPOGRAPHY = {
   INTER: 'inter',
   ROBOTO: 'roboto',
   MONTSERRAT: 'montserrat'
+} as const
+export type Typography = (typeof TYPOGRAPHY)[keyof typeof TYPOGRAPHY]
+
+export const TYPOGRAPHY_TO_FONT = {
+  [TYPOGRAPHY.INTER]: 'font-inter',
+  [TYPOGRAPHY.ROBOTO]: 'font-roboto',
+  [TYPOGRAPHY.MONTSERRAT]: 'font-montserrat'
 }

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
       cTextSecondary: '#E5ECFF'
     }
   },
+  safelist: [
+    'text-right',
+    'text-center',
+    'text-left',
+    'font-inter',
+    'font-roboto',
+    'font-montserrat'
+  ],
   presets: [
     presetUno(),
     presetWebFonts({


### PR DESCRIPTION
Fixes:
- AlignIcon's active state.
- Typography switch.
  - Since fonts are loaded dynamically, UnoCSS was stripping the fonts from the CSS output bundle. Adding the `font-*` properties to the `safelist` prevents UnoCSS from stripping them.
- Text-left-alignment.
  - Similar fix to the typography one.
- Added strict types to `ModeView`s and `Typography`s.